### PR TITLE
remove Cargo.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 **/*.rs.bk
-Cargo.lock
 /pkg


### PR DESCRIPTION
that's an essential file for ensuring builds are reproducible - it should always be in version control